### PR TITLE
For strings only, allow a leading slash.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,11 @@ Glob is implemented to have both a functional form and an object-oriented form. 
 
             glob"a/?/c"
 
+       Attempting to creat a GlobMatch object from a string with a leading `/` or the empty string is an error.
+
     2. A string, which will be converted into a GlobMatch expression:
 
-            "a/?/c" # equivalent to 1, above
+            "a/?/c" # equivalent to 1, above, except that a leading `/` is allowed here
 
     3. A vector of strings and/or objects which implement `ismatch`, including `Regex` and `Glob.FilenameMatch` objects
 
@@ -31,8 +33,6 @@ Glob is implemented to have both a functional form and an object-oriented form. 
         * no conversion of strings to `Glob.FilenameMatch` objects or directory splitting on `/` will occur.
 
     4. A trailing `/` (or equivalently, a trailing empty string in the vector) will cause glob to only match directories
-
-    5. Attempting to creat a GlobMatch object from a string with a leading `/` or the empty string is an error
 
 * `readdir(pattern::GlobMatch, [directory::String])` ::
   * alias for `glob()`

--- a/src/Glob.jl
+++ b/src/Glob.jl
@@ -343,6 +343,10 @@ function glob(pattern, prefix::String="")
     return matches
 end
 
+function glob(pattern::String)
+    first(pattern) == '/' ? glob(pattern[2:end], "/") : glob(pattern, "")
+end
+
 function _glob!(matches, pat::String)
     i = 1
     last = length(matches)


### PR DESCRIPTION
I was attempting to glob `"/dev/video*"` and found it annoying that I had to specify the directory path separately.

This PR only implements leading slash for the `glob` function called with strings, which was easy.  I started trying to implement it for `GlobMatch` objects, but found it would take more time than I have right now.  I'll open up a separate issue.
