### PR TITLE
Make play nice with FilePaths

### DIFF
--- a/src/Glob.jl
+++ b/src/Glob.jl
@@ -362,7 +362,7 @@ end
 readdir(pattern::GlobMatch, prefix::AbstractString="") = glob(pattern, prefix)
 
 function glob(pattern, prefix::AbstractString="")
-    matches = String[prefix]
+    matches = [prefix]
     for pat in GlobMatch(pattern).pattern
         matches = _glob!(matches, pat)
     end
@@ -387,7 +387,7 @@ function _glob!(matches, pat::AbstractString)
 end
 
 function _glob!(matches, pat)
-    m2 = String[]
+    m2 = eltype(matches)[]
     for m in matches
         if isempty(m)
             for d in readdir()


### PR DESCRIPTION
Without this PR glob mostly works on [FilePathsBase.jl types](https://github.com/rofinn/FilePathsBase.jl) at least for local `PosixPath`s.
but it returns results that are `Strings`.

By allowing the type for the `matches` arrays to be determined based on the type of the inputs,
we can fix that.

This will break when/if https://github.com/rofinn/FilePathsBase.jl/issues/15 comes though.
But til then at least this works.


cc @rofinn