### PR TITLE
Integrate with Cmd objects

### DIFF
--- a/src/Glob.jl
+++ b/src/Glob.jl
@@ -291,6 +291,25 @@ end
 macro glob_str(pattern) GlobMatch(pattern) end
 macro glob_mstr(pattern) GlobMatch(pattern) end
 
+"""
+    @g"GLOB"
+
+Create a Cmd object based on GLOB, allowing string interpolation.
+
+Relative globs are based on `pwd()`.
+"""
+macro g_str(pattern) :(do_g($(esc(Meta.parse("\"$(escape_string(pattern))\""))))) end
+
+function do_g(pattern)
+    pattern == "/" && return Cmd(["/"])
+    dir = pwd()
+    if pattern[1] == '/'
+        pattern = pattern[2:end]
+        dir = "/"
+    end
+    Cmd(glob(Glob.GlobMatch(pattern), dir))
+end
+
 struct GlobMatch
     pattern::Vector
     GlobMatch(pattern) = isempty(pattern) ? error("GlobMatch pattern cannot be an empty vector") : new(pattern)


### PR DESCRIPTION
This provides a `@g_str` macro that creates a Cmd object based on the interpolated contents.
This allows absolute paths and uses `pwd` for the directory if the glob not absolute.

If these files exist: `/tmp/a1`, `/tmp/a2`, and `/tmp/a3`,
then:
```
julia> import Glob.@g_str

julia> x="a"
"a"

julia> g"/tmp/$x*"
`/tmp/a1 /tmp/a2 /tmp/a3`
```